### PR TITLE
Determine _EntityArray address at runtime and update links to the base plugin.

### DIFF
--- a/Kill Counter/init.lua
+++ b/Kill Counter/init.lua
@@ -1889,7 +1889,7 @@ local function init()
 
     return {
         name = "Kill Counter",
-        version = "2.1.3",
+        version = "2.1.4",
         author = "staphen",
         description = "Tracks number of enemies defeated while playing",
         present = present

--- a/Kill Counter/init.lua
+++ b/Kill Counter/init.lua
@@ -36,7 +36,7 @@ local _SectionID = 0x00A9C4D8
 local _Location = 0x00AAFC9C
 
 local _EntityCount = 0x00AAE164
-local _EntityArray = 0x00AAD720
+local _EntityArray = 0
 
 local _MonsterUnitxtID = 0x378
 local _MonsterHP = 0x334
@@ -1730,6 +1730,12 @@ local function SessionInfoWindow(session)
 end
 
 local function present()
+    if _EntityArray == 0 then
+        -- Get the address of the entity array from one of the instructions that references it.
+        -- Works on base client and on a client patched with a different array.
+        _EntityArray = pso.read_u32(0x7B4BA0 + 2)
+    end
+	
     local isMenuOpen = (pso.read_u32(_MenuPointer) == 1)
 
     _Dimensions.update()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more in-depth information on how the Kill Counter works, please visit the
 [wiki](https://github.com/StephenCWills/psobb-kill-counter/wiki/How-it-works).
 
 ## Installation
-* Download [version 0.3.4](https://github.com/Solybum/psobbaddonplugin/releases/latest)
+* Download the [latest version](https://github.com/Solybum/psobbaddonplugin/releases/latest)
   of the [psobbaddonplugin](https://github.com/Solybum/psobbaddonplugin)
   project (bbmod.zip)
 * Extract the `dinput8.dll` file and place it in the root directory of your

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ For more in-depth information on how the Kill Counter works, please visit the
 [wiki](https://github.com/StephenCWills/psobb-kill-counter/wiki/How-it-works).
 
 ## Installation
-* Download [version 0.3.4](https://github.com/HybridEidolon/psobbaddonplugin/releases/tag/v0.3.4)
-  of the [psobbaddonplugin](https://github.com/HybridEidolon/psobbaddonplugin)
+* Download [version 0.3.4](https://github.com/Solybum/psobbaddonplugin/releases/latest)
+  of the [psobbaddonplugin](https://github.com/Solybum/psobbaddonplugin)
   project (bbmod.zip)
 * Extract the `dinput8.dll` file and place it in the root directory of your
   PSO installation


### PR DESCRIPTION
The next DLL for Ephinea will patch all _EntityArray references to use a new, larger array. Reading the address this way will work on both a base client and a patched client. The address is read out of an instruction used for clearing/initializing the array. The read operation could alternatively be done when _EntityArray is declared on most clients.

Updated the links in the README to point to the correct base plugin.